### PR TITLE
Adjust landing page mobile nav layout

### DIFF
--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -78,7 +78,7 @@ export default function Landing() {
           <div className="flex items-center gap-2 md:gap-3 shrink-0">
             <Link
               to="/book"
-              className="hidden md:block bg-[#0097b2] text-white px-4 py-2 md:px-6 md:py-3 rounded-lg text-sm md:text-lg font-semibold shadow-md animate-pulse-button whitespace-nowrap"
+              className="bg-[#0097b2] text-white px-4 py-2 md:px-6 md:py-3 rounded-lg text-sm md:text-lg font-semibold shadow-md animate-pulse-button whitespace-nowrap fixed bottom-4 left-1/2 -translate-x-1/2 z-50 md:static md:bottom-auto md:left-auto md:translate-x-0"
             >
               {t('nav.bookNow')}
             </Link>
@@ -102,13 +102,7 @@ export default function Landing() {
         </div>
       </nav>
 
-      {/* Mobile bottom-centered CTA */}
-      <Link
-        to="/book"
-        className="md:hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-50 bg-[#0097b2] text-white px-6 py-3 rounded-lg text-base font-semibold shadow-lg whitespace-nowrap"
-      >
-        {t('nav.bookNow')}
-      </Link>
+      
 
       {/* Hero Section */}
       <section className="flex flex-col items-center justify-center text-center px-6 pt-32 md:pt-40 pb-24 bg-gray-50">

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -44,10 +44,10 @@ export default function Landing() {
   };
 
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex flex-col min-h-screen pb-24 md:pb-0">
       {/* Navbar */}
       <nav className="bg-white shadow-md fixed w-full top-0 left-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 md:px-6 py-3 md:py-4 flex flex-wrap justify-between items-center gap-2">
+        <div className="max-w-7xl mx-auto px-4 md:px-6 py-3 md:py-4 flex flex-nowrap md:flex-wrap justify-between items-center gap-2">
           {/* Left side: Contact */}
           <div className="flex items-center space-x-3 md:space-x-6 min-w-0">
             {/* Logo */}
@@ -78,7 +78,7 @@ export default function Landing() {
           <div className="flex items-center gap-2 md:gap-3 shrink-0">
             <Link
               to="/book"
-              className="bg-[#0097b2] text-white px-4 py-2 md:px-6 md:py-3 rounded-lg text-sm md:text-lg font-semibold shadow-md animate-pulse-button whitespace-nowrap"
+              className="hidden md:block bg-[#0097b2] text-white px-4 py-2 md:px-6 md:py-3 rounded-lg text-sm md:text-lg font-semibold shadow-md animate-pulse-button whitespace-nowrap"
             >
               {t('nav.bookNow')}
             </Link>
@@ -101,6 +101,14 @@ export default function Landing() {
           </div>
         </div>
       </nav>
+
+      {/* Mobile bottom-centered CTA */}
+      <Link
+        to="/book"
+        className="md:hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-50 bg-[#0097b2] text-white px-6 py-3 rounded-lg text-base font-semibold shadow-lg whitespace-nowrap"
+      >
+        {t('nav.bookNow')}
+      </Link>
 
       {/* Hero Section */}
       <section className="flex flex-col items-center justify-center text-center px-6 pt-32 md:pt-40 pb-24 bg-gray-50">


### PR DESCRIPTION
Adjust mobile landing page navigation layout to place language icons on the right and the CTA button at the bottom center.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5e5ef73-424e-49f2-8ce5-80893a6c5d0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5e5ef73-424e-49f2-8ce5-80893a6c5d0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

